### PR TITLE
allow to set an ethereum block number in Web3::Eth::Rpc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+end
+desc "Run tests"

--- a/lib/web3/eth/contract.rb
+++ b/lib/web3/eth/contract.rb
@@ -92,7 +92,11 @@ module Web3
         def do_call web3_rpc, contract_address, args
           data = '0x' + signature_hash + encode_hex(encode_abi(input_types, args) )
 
-          response = web3_rpc.eth.call [{ to: contract_address, data: data}, 'latest']
+          block = web3_rpc.block
+          if block.is_a?(Numeric)
+            block = "0x#{block.to_s(16)}"
+          end
+          response = web3_rpc.eth.call [{ to: contract_address, data: data}, block]
 
           string_data = [remove_0x_head(response)].pack('H*')
           return nil if string_data.empty?

--- a/lib/web3/eth/contract.rb
+++ b/lib/web3/eth/contract.rb
@@ -38,7 +38,7 @@ module Web3
           @input_types = abi['inputs'] ? abi['inputs'].map{|a| parse_component_type a } : []
           @output_types = abi['outputs'].map{|a| parse_component_type a } if abi['outputs']
           @signature = Abi::Utils.function_signature @name, @input_types
-          @signature_hash = Abi::Utils.signature_hash @signature, (abi['type'].try(:downcase)=='event' ? 64 : 8)
+          @signature_hash = Abi::Utils.signature_hash @signature, (abi['type']&.downcase=='event' ? 64 : 8)
         end
 
         def parse_component_type argument
@@ -208,7 +208,7 @@ module Web3
 
         abi.each{|a|
 
-          case a['type'].try(:downcase)
+          case a['type']&.downcase
             when 'function'
               method = ContractMethod.new(a)
               @functions[method.name] = method

--- a/lib/web3/eth/rpc.rb
+++ b/lib/web3/eth/rpc.rb
@@ -16,10 +16,12 @@ module Web3
 
       DEFAULT_HOST = 'localhost'
       DEFAULT_PORT = 8545
+      DEFAULT_BLOCK = 'latest'
 
       attr_reader :eth, :connect_options
+      attr_accessor :block
 
-      def initialize host: DEFAULT_HOST, port: DEFAULT_PORT, connect_options: DEFAULT_CONNECT_OPTIONS
+      def initialize host: DEFAULT_HOST, port: DEFAULT_PORT, connect_options: DEFAULT_CONNECT_OPTIONS, block: DEFAULT_BLOCK
 
         @client_id = Random.rand 10000000
 
@@ -27,7 +29,7 @@ module Web3
         @connect_options = connect_options
 
         @eth = EthModule.new self
-
+        @block = block
       end
 
       def trace

--- a/test/web3/eth_test.rb
+++ b/test/web3/eth_test.rb
@@ -1,11 +1,8 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class Web3::EthTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Web3::Eth::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
-  end
 end

--- a/web3-eth.gemspec
+++ b/web3-eth.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('rlp', '~> 0.7.3')
   spec.add_dependency('digest-sha3', '~> 1.1.0')
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
This patch sets a variable in `Rpc` to use a specific block number when calling the web3 service. It can be updated after the Rpc class is built. My use case is I want to look at a contract function return value for a specific block, then see how it has changed in the next block. 

```ruby
WEB3 = Web3::Eth::Rpc.new host: 'mainnet.infura.io', 
                          port: 443,  
                          block: 11453808
```

also replaces rails `try` with 'safe navigation' `&.`