### PR TITLE
change to keccak gem for rubies > 2.2

### DIFF
--- a/web3-eth.gemspec
+++ b/web3-eth.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('rlp', '~> 0.7.3')
-  spec.add_dependency('digest-sha3', '~> 1.1.0')
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_dependency('keccak', '~> 1.2.2')
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
the original gem digest-sha3 is not maintained anymore and it doesn't work with new ruby versions 