### PR TITLE
gems: bump keccak to 1.3.0

### DIFF
--- a/lib/web3/eth/abi/utils.rb
+++ b/lib/web3/eth/abi/utils.rb
@@ -1,7 +1,7 @@
 # -*- encoding : ascii-8bit -*-
 
 require 'digest'
-require 'digest/sha3'
+require 'digest/keccak'
 require 'openssl'
 require 'rlp'
 
@@ -12,15 +12,12 @@ module Web3::Eth::Abi
 
     include Constant
 
-    ##
-    # Not the keccak in sha3, although it's underlying lib named SHA3
-    #
     def keccak256(x)
-      Digest::SHA3.new(256).digest(x)
+      Digest::Keccak.new(256).digest(x)
     end
 
     def keccak512(x)
-      Digest::SHA3.new(512).digest(x)
+      Digest::Keccak.new(512).digest(x)
     end
 
     def keccak256_rlp(x)

--- a/web3-eth.gemspec
+++ b/web3-eth.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency('rlp', '~> 0.7.3')
-  spec.add_dependency('digest-sha3', '~> 1.1.0')
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_dependency('rlp', '~> 0.7')
+  spec.add_dependency('keccak', '~> 1.3')
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "minitest", "~> 5.14"
 end


### PR DESCRIPTION
same as #3 but also renaming the SHA3 class for clarity.
* ref https://github.com/q9f/keccak.rb/pull/16